### PR TITLE
Render history

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,7 +102,6 @@ module.exports = function (grunt) {
       js: {
         files: ['<%=srcJs%>'],
         tasks: [
-          'clean:dist',
           'concat:dev'
         ],
         options: {
@@ -112,7 +111,6 @@ module.exports = function (grunt) {
       sass: {
         files: ['<%=srcSass%>'],
         tasks: [
-          'clean:dist',
           'concat:dev',
           'sass'
         ],
@@ -123,7 +121,6 @@ module.exports = function (grunt) {
       gruntfile: {
         files: ['Gruntfile.js'],
         tasks: [
-          'clean:dist',
           'concat:dev'
         ]
       }

--- a/examples/index.html
+++ b/examples/index.html
@@ -16,31 +16,47 @@ var options = {
   nodes: [
   {
     "id":0,
-    "title": "Some Title",
-    "content": "Do you want a thing or another thing?",
+    "title": "Are you having a good time?",
+    "content": "",
     "type": "pickOne",
     "triggers": [
       {
-        "content":"A thing",
+        "content":"Yah dude!",
         "target":1
       },
       {
-        "content":"Another thing",
-        "target":"FART"
+        "content":"Eh, not really.",
+        "target": 3
       }
     ]
   },
   {
     "id":1,
-    "title": "Another Title",
-    "content": "You are on another page.",
+    "title": "Do you want to continue having a good time?",
+    "content": "Don't let the good vibes end.",
+    "type": "pickOne",
+    "triggers": [
+      {
+        "content":"Yes, of course!",
+        "target": 4
+      },
+      {
+        "content":"I'm done for today.",
+        "target": 3
+      },
+    ]
+  },
+  {
+    "id": 3,
+    "title": "Okay.",
+    "content": "We are done here. The good times are complete. This should be a 'result'.",
     "type": "pickOne",
     "triggers": []
   },
   {
-    "id":"FART",
-    "title": "Third Title",
-    "content": "You are on yet another third page again.",
+    "id": 4,
+    "title": "Great.",
+    "content": "Continue having a good time! This should be a 'result'.",
     "type": "pickOne",
     "triggers": []
   }

--- a/examples/index.html
+++ b/examples/index.html
@@ -37,7 +37,7 @@ var options = {
     "type": "pickOne",
     "triggers": [
       {
-        "content":"Yes, of course!",
+        "content":"Let the good times roll.",
         "target": 4
       },
       {

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -88,7 +88,7 @@ var Wand = (function(wand, Handlebars) {
         }
       }
 
-
+      // append the wand history element
       wand.historyElem.appendChild(historyNodeElem);
     }
   }

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -39,7 +39,7 @@ var Wand = (function(wand, Handlebars) {
     switch (type) {
 
       case 'pickOne':
-        var button = wand.util.createElem('button', 'wand-trigger', triggerHtml);
+        var button = wand.util.createElem('button', 'wand_trigger', triggerHtml);
         button.onclick = function(event) {
           wand.engine.renderNode(trigger.target);
         };
@@ -72,19 +72,19 @@ var Wand = (function(wand, Handlebars) {
   // redraws every time a node renders using the state array
   function renderHistory(stateArray) {
     wand.historyElem.innerHTML = ""; // clear history
-    var historyList = wand.util.createElem('ol', 'wand-history');
+    var historyList = wand.util.createElem('ol', 'wand_history');
     for (var s = 0; s < stateArray.length - 1; s++) {
       var node = wand.util.getNodeObject(stateArray[s]); // get node that matches state
       var nextNodeId = stateArray[s + 1]; // get the next nodeId in the state array for finding user response
-      var historyNodeElem = wand.util.createElem('li', 'wand-history-node');
+      var historyNodeElem = wand.util.createElem('li', 'wand_history_node');
       
       // append the history title/question
-      historyNodeElem.innerHTML = '<span class="wand-history-title">'+node.title+'</span>';
+      historyNodeElem.innerHTML = '<span class="wand_history_title">'+node.title+'</span>';
 
       // find the user's given answer by checking the trigger targets
       for (var t = 0; t < node.triggers.length; t++) {
         if (nextNodeId == node.triggers[t].target) {
-          historyNodeElem.innerHTML += '<span class="wand-history-answer">'+node.triggers[t].content+'</strong>';
+          historyNodeElem.innerHTML += '<span class="wand_history_answer">'+node.triggers[t].content+'</strong>';
         }
       }
 

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -39,8 +39,7 @@ var Wand = (function(wand, Handlebars) {
     switch (type) {
 
       case 'pickOne':
-        var button = document.createElement('button');
-        button.innerHTML = triggerHtml;
+        var button = wand.util.createElem('button', 'wand-trigger', triggerHtml);
         button.onclick = function(event) {
           wand.engine.renderNode(trigger.target);
         };

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -22,8 +22,9 @@ var Wand = (function(wand, Handlebars) {
     }
     // push node into State array
     wand.state.addToState(nodeId);
+    renderHistory(wand.state.getState());
 
-    wand.elem.innerHTML = Handlebars.compile(wand.template.node)(node);
+    wand.nodeContainer.innerHTML = Handlebars.compile(wand.template.node)(node);
     if (node.triggers) {
       for (var i = node.triggers.length - 1; i >= 0; i--) {
         renderTrigger(node.triggers[i], i, node.type);
@@ -44,7 +45,7 @@ var Wand = (function(wand, Handlebars) {
           wand.engine.renderNode(trigger.target);
         };
 
-        wand.elem.appendChild(button);
+        wand.nodeContainer.appendChild(button);
 
         break;
 
@@ -62,11 +63,34 @@ var Wand = (function(wand, Handlebars) {
           });
         };
 
-        wand.elem.appendChild(elem);
+        wand.nodeContainer.appendChild(elem);
 
         break;
     }
 
+  }
+
+  // redraws every time a node renders using the state array
+  function renderHistory(stateArray) {
+    wand.historyElem.innerHTML = ""; // clear history
+    for (var s = 0; s < stateArray.length - 1; s++) {
+      var node = wand.util.getNodeObject(stateArray[s]); // get node that matches state
+      var nextNodeId = stateArray[s + 1]; // get the next nodeId in the state array for finding user response
+      var historyNodeElem = wand.util.createElem('li', 'wand-history-node');
+      
+      // append the history title/question
+      historyNodeElem.innerHTML = '<span class="wand-history-title">'+node.title+'</span>';
+
+      // find the user's given answer by checking the trigger targets
+      for (var t = 0; t < node.triggers.length; t++) {
+        if (nextNodeId == node.triggers[t].target) {
+          historyNodeElem.innerHTML += '<span class="wand-history-answer">'+node.triggers[t].content+'</strong>';
+        }
+      }
+
+
+      wand.historyElem.appendChild(historyNodeElem);
+    }
   }
 
   return wand;

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -72,6 +72,7 @@ var Wand = (function(wand, Handlebars) {
   // redraws every time a node renders using the state array
   function renderHistory(stateArray) {
     wand.historyElem.innerHTML = ""; // clear history
+    var historyList = wand.util.createElem('ol', 'wand-history');
     for (var s = 0; s < stateArray.length - 1; s++) {
       var node = wand.util.getNodeObject(stateArray[s]); // get node that matches state
       var nextNodeId = stateArray[s + 1]; // get the next nodeId in the state array for finding user response
@@ -88,8 +89,9 @@ var Wand = (function(wand, Handlebars) {
       }
 
       // append the wand history element
-      wand.historyElem.appendChild(historyNodeElem);
+      historyList.appendChild(historyNodeElem);
     }
+    wand.historyElem.appendChild(historyList);
   }
 
   return wand;

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -18,9 +18,6 @@ var Wand = (function(wand) {
 
   };
 
-  // wand.template.history = {
-  //   'node': ''
-  // }
-
   return wand;
+  
 }(Wand || {}));

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -6,8 +6,8 @@ var Wand = (function(wand) {
   wand.template = {};
 
   // puts stuff into a template
-  wand.template.node = '<h1>{{title}}</h1>' +
-    '<div class="node-contents">{{content}}</div>';
+  wand.template.node = '<h1 class="wand-node-title">{{title}}</h1>' +
+    '<div class="wand-node-content">{{content}}</div>';
 
   wand.template.triggers = {
 

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -18,5 +18,9 @@ var Wand = (function(wand) {
 
   };
 
+  // wand.template.history = {
+  //   'node': ''
+  // }
+
   return wand;
 }(Wand || {}));

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -28,8 +28,12 @@ var Wand = (function(wand) {
   // creates a DOM node with specified classNames
   wand.util.createElem = function(type, className, id) {
     var elem = document.createElement(type);
-    if (className) elem.className = className;
-    if (id) elem.id = id;
+    if (className) {
+      elem.className = className;
+    }
+    if (id) {
+      elem.id = id;
+    }
     return elem;
   };
 
@@ -40,7 +44,7 @@ var Wand = (function(wand) {
         return wand.opts.nodes[n];
       }
     }
-  }
+  };
 
 
   return wand;

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -25,6 +25,23 @@ var Wand = (function(wand) {
     return xhr;
   }
 
+  // creates a DOM node with specified classNames
+  wand.util.createElem = function(type, className) {
+    var elem = document.createElement(type);
+    if (className) elem.className = className;
+    return elem;
+  };
+
+  // will get a node object by ID
+  wand.util.getNodeObject = function(nodeId) {
+    for (var n = 0; n < wand.opts.nodes.length; n++) {
+      if (nodeId === wand.opts.nodes[n].id) {
+        return wand.opts.nodes[n];
+      }
+    }
+  }
+
+
   return wand;
 
 }(Wand || {}));

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -25,14 +25,14 @@ var Wand = (function(wand) {
     return xhr;
   }
 
-  // creates a DOM node with specified classNames
-  wand.util.createElem = function(type, className, id) {
+  // creates a DOM node with specified classNames and id
+  wand.util.createElem = function(type, className, innerHTML) {
     var elem = document.createElement(type);
     if (className) {
       elem.className = className;
     }
-    if (id) {
-      elem.id = id;
+    if (innerHTML) {
+      elem.innerHTML = innerHTML;
     }
     return elem;
   };

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -26,9 +26,10 @@ var Wand = (function(wand) {
   }
 
   // creates a DOM node with specified classNames
-  wand.util.createElem = function(type, className) {
+  wand.util.createElem = function(type, className, id) {
     var elem = document.createElement(type);
     if (className) elem.className = className;
+    if (id) elem.id = id;
     return elem;
   };
 

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -29,7 +29,7 @@ var Wand = (function(wand) {
       wand.historyElem = wand.util.createElem('ol', 'wand-history');
       wand.elem.appendChild(wand.historyElem);
     }
-    wand.nodeContainer = wand.util.createElem('div', 'wand-node-container', 'my-custom-id');
+    wand.nodeContainer = wand.util.createElem('div', 'wand-node-container');
     wand.elem.appendChild(wand.nodeContainer);
 
 

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -26,7 +26,7 @@ var Wand = (function(wand) {
 
     // create sidebar to show history unless the user specifies false
     if (!opts.history) {
-      wand.historyElem = wand.util.createElem('ol', 'wand-history');
+      wand.historyElem = wand.util.createElem('aside', 'wand-history-container');
       wand.elem.appendChild(wand.historyElem);
     }
     wand.nodeContainer = wand.util.createElem('div', 'wand-node-container');

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -22,7 +22,7 @@ var Wand = (function(wand) {
 
     nodes = opts.nodes;
     wand.elem = document.getElementById(opts.elem);
-    wand.elem.className += ' wand';
+    wand.elem.className += ' wand-container';
 
     // create sidebar to show history unless the user specifies false
     if (!opts.history) {

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -29,7 +29,7 @@ var Wand = (function(wand) {
       wand.historyElem = wand.util.createElem('ol', 'wand-history');
       wand.elem.appendChild(wand.historyElem);
     }
-    wand.nodeContainer = wand.util.createElem('div', 'wand-node-container');
+    wand.nodeContainer = wand.util.createElem('div', 'wand-node-container', 'my-custom-id');
     wand.elem.appendChild(wand.nodeContainer);
 
 

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -22,7 +22,7 @@ var Wand = (function(wand) {
 
     nodes = opts.nodes;
     wand.elem = document.getElementById(opts.elem);
-    wand.elem.className += ' wand';
+    wand.elem.className += ' wand wand-blue';
 
     // create sidebar to show history unless the user specifies false
     if (!opts.history) {

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -22,14 +22,14 @@ var Wand = (function(wand) {
 
     nodes = opts.nodes;
     wand.elem = document.getElementById(opts.elem);
-    wand.elem.className += ' wand wand-blue';
+    wand.elem.className += ' wand';
 
     // create sidebar to show history unless the user specifies false
     if (!opts.history) {
-      wand.historyElem = wand.util.createElem('aside', 'wand-history-container');
+      wand.historyElem = wand.util.createElem('aside', 'wand_history_container');
       wand.elem.appendChild(wand.historyElem);
     }
-    wand.nodeContainer = wand.util.createElem('div', 'wand-node-container');
+    wand.nodeContainer = wand.util.createElem('div', 'wand_node_container');
     wand.elem.appendChild(wand.nodeContainer);
 
 

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -19,9 +19,19 @@ var Wand = (function(wand) {
 
     wand.opts = opts;
 
+
     nodes = opts.nodes;
     wand.elem = document.getElementById(opts.elem);
     wand.elem.className += ' wand';
+
+    // create sidebar to show history unless the user specifies false
+    if (!opts.history) {
+      wand.historyElem = wand.util.createElem('ol', 'wand-history');
+      wand.elem.appendChild(wand.historyElem);
+    }
+    wand.nodeContainer = wand.util.createElem('div', 'wand-node-container');
+    wand.elem.appendChild(wand.nodeContainer);
+
 
     validateWand();
 

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -6,25 +6,25 @@ html {
 
 // used for theme skins with a default to gray
 @mixin color_cascade($color: #999) {
-  .wand-trigger {
+  .wand_trigger {
     border: 2px solid $color;
     color: $color;
   }
-  .wand-history-node {
+  .wand_history_node {
     border-color: $color;
     &:before {
       background-color: white;
       border: 0.2em solid $color;
     }
   }
-  .wand-node-container {
+  .wand_node_container {
     border-color: $color;
     &:before {
       background-color: $color;
       border: 0.2em solid $color;
     }
   }
-  .wand-history-title {
+  .wand_history_title {
     color: $color;
   }
 }
@@ -40,8 +40,8 @@ html {
     @include color_cascade(brick-red);
   }
 }
-.wand-node {}
-.wand-node-container {
+.wand_node {}
+.wand_node_container {
   border-left-width: 0.2em;
   border-left-style: solid;
   padding: 0.2em 1em 1em;
@@ -66,15 +66,15 @@ html {
     background: steelblue;
   }
 }
-.wand-node-title {
+.wand_node_title {
   font-size: 1.5em;
   margin: -0.4em 0 0.5em;
 }
-.wand-node-content {
+.wand_node_content {
   margin: 0;
 }
 
-.wand-trigger {
+.wand_trigger {
   text-transform:uppercase;
   padding: 1em 2em;
   font-size: 0.7em;
@@ -85,16 +85,16 @@ html {
   cursor: pointer;
 }
 
-.wand-history-container {
+.wand_history_container {
   width: 400px; // temporary
   margin: 0;
 }
-.wand-history {
+.wand_history {
   list-style-type: none;
   margin: 0;
   padding: 1em 1em 0;
 }
-.wand-history-node {
+.wand_history_node {
   position: relative;
   padding: 0 0 20px 1em;
   border-left-width: 0.2em;
@@ -112,8 +112,8 @@ html {
     padding-bottom: 3em;
   }
 }
-.wand-history-title {}
-.wand-history-answer { 
+.wand_history_title {}
+.wand_history_answer { 
   font-size: 0.9em;
   display: block;
   font-weight: 900;

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -4,11 +4,74 @@ html {
   font-family: sans-serif;
 }
 
+// used for theme skins with a default to gray
+@mixin color_cascade($color: #999) {
+  .wand-trigger {
+    border: 2px solid $color;
+    color: $color;
+  }
+  .wand-history-node {
+    border-color: $color;
+    &:before {
+      background-color: $color;
+    }
+  }
+  .wand-history-answer {
+    color: $color;
+  }
+}
 
-.wand {}
+.wand {
+  @include color_cascade();
+  
+  &.wand-blue {
+    @include color_cascade(steelblue);
+  }
+
+  &.wand-red {
+    @include color_cascade(brick-red);
+  }
+}
 .wand-node {}
 .wand-node-container {}
-.wand-history {}
-.wand-history-node {}
-.wand-history-title {}
-.wand-history-answer { display: block; color: #c0c0c0; }
+
+.wand-trigger {
+  text-transform:uppercase;
+  padding: 1em 2em;
+  font-size: 0.7em;
+  letter-spacing: 0.1em;
+  background: transparent;
+  margin-right: 1em;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.wand-history {
+  width: 400px;
+  list-style-type: none;
+  margin: 0;
+  padding: 1em;
+}
+.wand-history-node {
+  position: relative;
+  padding: 0 0 20px 1em;
+  border-left-width: 0.15em;
+  border-left-style: solid;
+  &:before {
+    content: " ";
+    position: absolute;
+    top: 0;
+    left: -0.55em;
+    width: 0.6em;
+    height: 0.6em;
+    border-radius: 50%;
+    border: 0.2em solid white;
+  }
+}
+.wand-history-title {
+  font-weight: 800;
+}
+.wand-history-answer { 
+  font-size: 0.9em;
+  display: block;
+}

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -4,6 +4,7 @@ html {
   font-family: sans-serif;
 }
 
+
 .wand {}
 .wand-node {}
 .wand-node-container {}

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -29,9 +29,9 @@ html {
   }
 }
 
-.wand {
+.wand-container {
   @include color_cascade();
-  
+
   &.wand-blue {
     @include color_cascade(steelblue);
   }
@@ -39,82 +39,83 @@ html {
   &.wand-red {
     @include color_cascade(brick-red);
   }
-}
-.wand_node {}
-.wand_node_container {
-  border-left-width: 0.2em;
-  border-left-style: solid;
-  padding: 0.2em 1em 1em;
-  margin-left: 1em;
-  position: relative;
-  &:before {
-    content: " ";
-    position: absolute;
-    top: 0;
-    left: -0.55em;
-    width: 0.55em;
-    height: 0.55em;
-    border-radius: 100%;
-  }
-  &:after {
-    position: absolute;
-    content: " ";
-    bottom: 0;
-    left: -0.55em;
-    width: 0.9em;
-    height: 0.2em;
-    background: steelblue;
-  }
-}
-.wand_node_title {
-  font-size: 1.5em;
-  margin: -0.4em 0 0.5em;
-}
-.wand_node_content {
-  margin: 0;
-}
 
-.wand_trigger {
-  text-transform:uppercase;
-  padding: 1em 2em;
-  font-size: 0.7em;
-  letter-spacing: 0.1em;
-  background: transparent;
-  margin-right: 1em;
-  font-weight: 700;
-  cursor: pointer;
-}
+  .wand_node {}
+  .wand_node_container {
+    border-left-width: 0.2em;
+    border-left-style: solid;
+    padding: 0.2em 1em 1em;
+    margin-left: 1em;
+    position: relative;
+    &:before {
+      content: " ";
+      position: absolute;
+      top: 0;
+      left: -0.55em;
+      width: 0.55em;
+      height: 0.55em;
+      border-radius: 100%;
+    }
+    &:after {
+      position: absolute;
+      content: " ";
+      bottom: 0;
+      left: -0.55em;
+      width: 0.9em;
+      height: 0.2em;
+      background: steelblue;
+    }
+  }
+  .wand_node_title {
+    font-size: 1.5em;
+    margin: -0.4em 0 0.5em;
+  }
+  .wand_node_content {
+    margin: 0;
+  }
 
-.wand_history_container {
-  width: 400px; // temporary
-  margin: 0;
-}
-.wand_history {
-  list-style-type: none;
-  margin: 0;
-  padding: 1em 1em 0;
-}
-.wand_history_node {
-  position: relative;
-  padding: 0 0 20px 1em;
-  border-left-width: 0.2em;
-  border-left-style: solid;
-  &:before {
-    content: " ";
-    position: absolute;
-    top: 0;
-    left: -0.55em;
-    width: 0.55em;
-    height: 0.55em;
-    border-radius: 100%;
+  .wand_trigger {
+    text-transform:uppercase;
+    padding: 1em 2em;
+    font-size: 0.7em;
+    letter-spacing: 0.1em;
+    background: transparent;
+    margin-right: 1em;
+    font-weight: 700;
+    cursor: pointer;
   }
-  &:last-child {
-    padding-bottom: 3em;
+
+  .wand_history_container {
+    width: 400px; // temporary
+    margin: 0;
   }
-}
-.wand_history_title {}
-.wand_history_answer { 
-  font-size: 0.9em;
-  display: block;
-  font-weight: 900;
+  .wand_history {
+    list-style-type: none;
+    margin: 0;
+    padding: 1em 1em 0;
+  }
+  .wand_history_node {
+    position: relative;
+    padding: 0 0 20px 1em;
+    border-left-width: 0.2em;
+    border-left-style: solid;
+    &:before {
+      content: " ";
+      position: absolute;
+      top: 0;
+      left: -0.55em;
+      width: 0.55em;
+      height: 0.55em;
+      border-radius: 100%;
+    }
+    &:last-child {
+      padding-bottom: 3em;
+    }
+  }
+  .wand_history_title {}
+  .wand_history_answer {
+    font-size: 0.9em;
+    display: block;
+    font-weight: 900;
+  }
 }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -13,10 +13,18 @@ html {
   .wand-history-node {
     border-color: $color;
     &:before {
-      background-color: $color;
+      background-color: white;
+      border: 0.2em solid $color;
     }
   }
-  .wand-history-answer {
+  .wand-node-container {
+    border-color: $color;
+    &:before {
+      background-color: $color;
+      border: 0.2em solid $color;
+    }
+  }
+  .wand-history-title {
     color: $color;
   }
 }
@@ -33,7 +41,38 @@ html {
   }
 }
 .wand-node {}
-.wand-node-container {}
+.wand-node-container {
+  border-left-width: 0.2em;
+  border-left-style: solid;
+  padding: 0.2em 1em 1em;
+  margin-left: 1em;
+  position: relative;
+  &:before {
+    content: " ";
+    position: absolute;
+    top: 0;
+    left: -0.55em;
+    width: 0.55em;
+    height: 0.55em;
+    border-radius: 100%;
+  }
+  &:after {
+    position: absolute;
+    content: " ";
+    bottom: 0;
+    left: -0.55em;
+    width: 0.9em;
+    height: 0.2em;
+    background: steelblue;
+  }
+}
+.wand-node-title {
+  font-size: 1.5em;
+  margin: -0.4em 0 0.5em;
+}
+.wand-node-content {
+  margin: 0;
+}
 
 .wand-trigger {
   text-transform:uppercase;
@@ -47,31 +86,32 @@ html {
 }
 
 .wand-history {
-  width: 400px;
+  width: 400px; // temporary
   list-style-type: none;
   margin: 0;
-  padding: 1em;
+  padding: 1em 1em 0;
 }
 .wand-history-node {
   position: relative;
   padding: 0 0 20px 1em;
-  border-left-width: 0.15em;
+  border-left-width: 0.2em;
   border-left-style: solid;
   &:before {
     content: " ";
     position: absolute;
     top: 0;
     left: -0.55em;
-    width: 0.6em;
-    height: 0.6em;
-    border-radius: 50%;
-    border: 0.2em solid white;
+    width: 0.55em;
+    height: 0.55em;
+    border-radius: 100%;
+  }
+  &:last-child {
+    padding-bottom: 3em;
   }
 }
-.wand-history-title {
-  font-weight: 800;
-}
+.wand-history-title {}
 .wand-history-answer { 
   font-size: 0.9em;
   display: block;
+  font-weight: 900;
 }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -1,5 +1,13 @@
 // scss goes here
 
 html {
-  font-family: helvetica;
+  font-family: sans-serif;
 }
+
+.wand {}
+.wand-node {}
+.wand-node-container {}
+.wand-history {}
+.wand-history-node {}
+.wand-history-title {}
+.wand-history-answer { display: block; color: #c0c0c0; }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -85,8 +85,11 @@ html {
   cursor: pointer;
 }
 
-.wand-history {
+.wand-history-container {
   width: 400px; // temporary
+  margin: 0;
+}
+.wand-history {
   list-style-type: none;
   margin: 0;
   padding: 1em 1em 0;

--- a/test/unit/wand.plugin.spec.js
+++ b/test/unit/wand.plugin.spec.js
@@ -2,7 +2,7 @@ describe('Wand plugin', function () {
 
   var _elem, wand;
   var expect = chai.expect;
-  var elemId = 'testDiv';
+  var elemId = 'pluginSpecDiv';
   var nodes = [{"id": 0, 'triggers': []}];
   var opts = {elem: elemId, nodes: nodes};
 
@@ -10,6 +10,13 @@ describe('Wand plugin', function () {
     var _elem = document.createElement('div');
     _elem.setAttribute('id', elemId);
     document.body.appendChild(_elem);
+  });
+
+  afterEach(function() {
+    var node = document.getElementById(elemId);
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
   });
 
   it('should allow for new public methods on wand object', function(){

--- a/test/unit/wand.spec.js
+++ b/test/unit/wand.spec.js
@@ -3,7 +3,7 @@ describe('Wand', function () {
 
   var _elem, wand, opts;
   var expect = chai.expect;
-  var elemId = 'testDiv';
+  var elemId = 'wandSpecDiv';
   var nodes = [{"id": 0, 'type': 'pickOne', 'title': "node 0 title", "content": "foo", "triggers": []}];
   var badApiTrigger = [{"callbackFn": "DOESNOTEXIST", "content": "test"}];
   var goodApiTrigger = [{"callbackFn": "aFunction", "content": "test"}];
@@ -23,6 +23,10 @@ describe('Wand', function () {
 
   afterEach(function() {
     opts = {};
+    var node = document.getElementById(elemId);
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
   });
 
   it('should fail without any options', function () {

--- a/test/unit/wand.spec.js
+++ b/test/unit/wand.spec.js
@@ -50,6 +50,11 @@ describe('Wand', function () {
     wand.init(opts);
   });
 
+  it('should have a container class of wand-container', function () {
+    wand.init(opts);
+    expect(document.getElementsByClassName('wand-container').length).to.eq(1);
+  });
+
   describe('Wand API Node', function() {
 
     beforeEach(function() {

--- a/test/unit/wand.state.spec.js
+++ b/test/unit/wand.state.spec.js
@@ -2,7 +2,7 @@ describe('Wand State', function() {
 
   var _elem, wand;
   var expect = chai.expect;
-  var elemId = 'testDiv';
+  var elemId = 'stateSpecDiv';
   var opts = {
     elem: elemId,
     nodes: [{
@@ -22,6 +22,10 @@ describe('Wand State', function() {
 
   afterEach(function() {
     window.history.pushState(null, null, '/');
+    var node = document.getElementById(elemId);
+    if (node.parentNode) {
+      node.parentNode.removeChild(node);
+    }
   });
 
   it('should check for wandState queryString and set history appropriately', function() {
@@ -46,7 +50,6 @@ describe('Wand State', function() {
 
     it('should know the second node', function() {
       document.getElementById(elemId).getElementsByTagName("button")[0].click();
-      console.log(Wand.state.getState());
       expect(Wand.state.getState()).to.deep.equal([0, 1]);
     });
 

--- a/test/unit/wand.state.spec.js
+++ b/test/unit/wand.state.spec.js
@@ -50,25 +50,25 @@ describe('Wand State', function() {
       expect(Wand.state.getState()).to.deep.equal([0, 1]);
     });
 
-    // it('should encode the state into the url', function() {
-    //   expect(getParameterByName("wandState")).to.equal("0");
-    // });
+    it('should encode the state into the url', function() {
+      expect(getParameterByName("wandState")).to.equal("0");
+    });
 
-    // it('should encode the state past the first node into the url', function() {
-    //   document.getElementById(elemId).getElementsByTagName("button")[0].click();
-    //   expect(getParameterByName("wandState")).to.equal("0,1");
-    // });
+    it('should encode the state past the first node into the url', function() {
+      document.getElementById(elemId).getElementsByTagName("button")[0].click();
+      expect(getParameterByName("wandState")).to.equal("0,1");
+    });
 
-    // it('should navigate back properly', function(done) {
-    //   document.getElementById(elemId).getElementsByTagName("button")[0].click();
-    //   // setTimeout from http://cgrune.com/2013/10/25/testing-window-history/
-    //   setTimeout(function() {
-    //     window.history.back();
-    //   }, 10);
-    //   done();
-    //   expect(getParameterByName("wandState")).to.equal("0");
-    //   expect(Wand.state.getState()).to.deep.equal([0]);
-    // });
+    it('should navigate back properly', function(done) {
+      document.getElementById(elemId).getElementsByTagName("button")[0].click();
+      // setTimeout from http://cgrune.com/2013/10/25/testing-window-history/
+      setTimeout(function() {
+        window.history.back();
+      }, 10);
+      done();
+      expect(getParameterByName("wandState")).to.equal("0");
+      expect(Wand.state.getState()).to.deep.equal([0]);
+    });
 
   });
   var addUrlParam = function(search, key, val) {

--- a/test/unit/wand.state.spec.js
+++ b/test/unit/wand.state.spec.js
@@ -46,28 +46,29 @@ describe('Wand State', function() {
 
     it('should know the second node', function() {
       document.getElementById(elemId).getElementsByTagName("button")[0].click();
+      console.log(Wand.state.getState());
       expect(Wand.state.getState()).to.deep.equal([0, 1]);
     });
 
-    it('should encode the state into the url', function() {
-      expect(getParameterByName("wandState")).to.equal("0");
-    });
+    // it('should encode the state into the url', function() {
+    //   expect(getParameterByName("wandState")).to.equal("0");
+    // });
 
-    it('should encode the state past the first node into the url', function() {
-      document.getElementById(elemId).getElementsByTagName("button")[0].click();
-      expect(getParameterByName("wandState")).to.equal("0,1");
-    });
+    // it('should encode the state past the first node into the url', function() {
+    //   document.getElementById(elemId).getElementsByTagName("button")[0].click();
+    //   expect(getParameterByName("wandState")).to.equal("0,1");
+    // });
 
-    it('should navigate back properly', function(done) {
-      document.getElementById(elemId).getElementsByTagName("button")[0].click();
-      // setTimeout from http://cgrune.com/2013/10/25/testing-window-history/
-      setTimeout(function() {
-        window.history.back();
-      }, 10);
-      done();
-      expect(getParameterByName("wandState")).to.equal("0");
-      expect(Wand.state.getState()).to.deep.equal([0]);
-    });
+    // it('should navigate back properly', function(done) {
+    //   document.getElementById(elemId).getElementsByTagName("button")[0].click();
+    //   // setTimeout from http://cgrune.com/2013/10/25/testing-window-history/
+    //   setTimeout(function() {
+    //     window.history.back();
+    //   }, 10);
+    //   done();
+    //   expect(getParameterByName("wandState")).to.equal("0");
+    //   expect(Wand.state.getState()).to.deep.equal([0]);
+    // });
 
   });
   var addUrlParam = function(search, key, val) {


### PR DESCRIPTION
This PR does a few major things:
- renders a visual history based on user responses, using the `renderHistory()` function in `engine.js`. This essentially redraws the history after every click using the state array
- builds history in the `.wand-history` ordered list, and pushes all of the node renderings into `.wand-node-container` - preparing us for styling
- starts building out some CSS because I can't stand looking at those un-styled buttons :stuck_out_tongue_winking_eye: 

There are two new utility functions as well:
1. `wand.util.getNodeObject(nodeId)`, which is essentially a node search, that returns the entire node object based on Id - currently used in the history renderings
2. `wand.util.createElem(type, className, innerHTML)` for simplifying the DOM element creation process - returns a DOM object

This is a pretty big PR, and @bsmithgall asked me to build off of `api`. Tests are currently not working, and I would be happy to split this into different PR's for the different features (especially since styles come along with this).

![wand-visualhistory](https://cloud.githubusercontent.com/assets/1943001/9023606/b651f9da-3868-11e5-9071-654502675e38.gif)
