### PR TITLE
API trigger experiment branch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,8 @@ module.exports = function (grunt) {
 
     concat: {
       options: {
-        separator: ';'
+        separator: ';',
+        sourceMap: true
       },
       dev: {
         src: [
@@ -93,7 +94,7 @@ module.exports = function (grunt) {
           '<%=handlebars%>/handlebars.js',
           '<%=srcJs%>'
         ],
-        dest: '<%=buildDir%>/wand.js'
+        dest: '<%=buildDir%>/wand.js',
       },
     },
 

--- a/examples/api.html
+++ b/examples/api.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title></title>
+  <link rel="stylesheet" type="text/css" href="../dist/main.css"/>
+
+</head>
+<body>
+<div id="wizard"></div>
+
+<script src="../dist/wand.js"></script>
+<script>
+
+function handleYesNoApi(xhrResponse) {
+  return JSON.parse(xhrResponse).answer === 'yes' ? 1 : 2;
+}
+
+var options = {
+  elem: "wizard",
+  nodes: [
+  {
+    "id":0,
+    "title": "Some Title",
+    "content": "Do you want a thing or another thing?",
+    "type": "api",
+    "triggers": [
+      {
+        "content": "Is it yes or no?",
+        "api": "http://yesno.wtf/api",
+        "callbackFn": "handleYesNoApi"
+      }
+    ]
+  },
+  {
+    "id": 1,
+    "title": "YES!",
+    "content": "You got yes!",
+    "type": "pickOne",
+    "triggers": []
+  },
+  {
+    "id": 2,
+    "title": "NO!",
+    "content": "You got no!",
+    "type": "pickOne",
+    "triggers": []
+  }],
+  callbackFns: {
+    'handleYesNoApi': handleYesNoApi
+  }
+};
+
+Wand.init(options);
+
+</script>
+
+</body>
+</html>

--- a/examples/api.html
+++ b/examples/api.html
@@ -11,9 +11,10 @@
 <script src="../dist/wand.js"></script>
 <script>
 
-function handleYesNoApi(xhrResponse) {
+var nested = {};
+nested.handleYesNoApi = function (xhrResponse) {
   return JSON.parse(xhrResponse).answer === 'yes' ? 1 : 2;
-}
+};
 
 var options = {
   elem: "wizard",
@@ -27,7 +28,7 @@ var options = {
       {
         "content": "Is it yes or no?",
         "api": "http://yesno.wtf/api",
-        "callbackFn": "handleYesNoApi"
+        "callbackFn": "nested.handleYesNoApi"
       }
     ]
   },
@@ -45,9 +46,6 @@ var options = {
     "type": "pickOne",
     "triggers": []
   }],
-  callbackFns: {
-    'handleYesNoApi': handleYesNoApi
-  }
 };
 
 Wand.init(options);

--- a/examples/api.html
+++ b/examples/api.html
@@ -8,44 +8,74 @@
 <body>
 <div id="wizard"></div>
 
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDzCsQTTBA7AbrjxE6R5vwnZkL0q7Ev48Q"></script>
 <script src="../dist/wand.js"></script>
 <script>
 
 var nested = {};
-nested.handleYesNoApi = function (xhrResponse) {
-  return JSON.parse(xhrResponse).answer === 'yes' ? 1 : 2;
+nested.preprocessor = function(address) {
+  // Preprocessors are optional.
+  /*
+  var geocoder = new google.maps.Geocoder();
+
+  geocoder.geocode(
+    {
+      "address": address,
+      "componentRestrictions": { "administrativeArea" : "Miami-Dade County" }
+    },
+    function(results, status) {
+      if (status == google.maps.GeocoderStatus.OK) {
+        lat = results[0].geometry.location.A;
+        lng = results[0].geometry.location.F;
+        return { lat: lat, lon: lng }
+      } else {
+          alert("Geocode was not successful for the following reason: " + status);
+      }
+    });
+
+  return address;
+  */
+  return { lat: 25.840171, lon: -8.179727 };
+};
+
+nested.handleYesNoApi = function(xhrResponse) {
+  // return JSON.parse(xhrResponse).answer === 'yes' ? 1 : 2;
+  return xhrResponse.features.length > 0 ? 'UMSA_false' : 'UMSA_true';
 };
 
 var options = {
-  elem: "wizard",
-  nodes: [
+  "elem": "wizard",
+  "nodes": [
   {
     "id":0,
-    "title": "Some Title",
-    "content": "Do you want a thing or another thing?",
+    "title": "The county check!",
+    "content": "Enter your address in Miami:",
     "type": "api",
     "triggers": [
       {
-        "content": "Is it yes or no?",
-        "api": "http://yesno.wtf/api",
-        "callbackFn": "nested.handleYesNoApi"
+        "content": "submit",
+        "api": "http://still-eyrie-4551.herokuapp.com/areas",
+        "preprocessor": "nested.preprocessor",
+        "callbackFn": "nested.handleYesNoApi",
+        "jsonp": true
       }
     ]
   },
   {
-    "id": 1,
+    "id": "UMSA_false",
     "title": "YES!",
-    "content": "You got yes!",
+    "content": "You are in a municipality in Miami-Dade.",
     "type": "pickOne",
     "triggers": []
   },
   {
-    "id": 2,
+    "id": "UMSA_true",
     "title": "NO!",
-    "content": "You got no!",
+    "content": "You are in Unincorporated Miami-Dade County!",
     "type": "pickOne",
     "triggers": []
-  }],
+  }]
 };
 
 Wand.init(options);

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -56,6 +56,7 @@ var Wand = (function(wand, Handlebars) {
         var submitButton = elem.querySelector('#Wand-submit-' + trigger._id);
 
         submitButton.onclick = function(event) {
+          var response;
           var inputData = elem.querySelector('#Wand-input-' + trigger._id);
 
           if (trigger.preprocessor) {
@@ -63,11 +64,11 @@ var Wand = (function(wand, Handlebars) {
           }
 
           if (trigger.jsonp === true) {
-            var response = wand.util.loadJsonp(trigger.api, params, function(data) {
+            response = wand.util.loadJsonp(trigger.api, params, function(data) {
               wand.engine.renderNode(trigger.callbackFn(data));
             });
           } else {
-            var response = wand.util.loadXhr(trigger, params, function(xhr) {
+            response = wand.util.loadXhr(trigger, params, function(xhr) {
               if (xhr.status === 200) {
                 wand.engine.renderNode(trigger.callbackFn(xhr.response));
               } else {

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -32,11 +32,23 @@ var Wand = (function(wand, Handlebars) {
   };
 
   function renderTrigger(trigger, type) {
-    var button = document.createElement('button');
-    button.innerHTML = Handlebars.compile(wand.template.triggers[type])(trigger);
-    button.onclick = function(event) {
-      wand.engine.renderNode(trigger.target);
-    };
+    var triggerHtml = Handlebars.compile(wand.template.triggers[type])(trigger);
+
+    switch (type) {
+
+      case 'pickOne':
+        var button = document.createElement('button');
+        button.innerHTML = triggerHtml;
+        button.onclick = function(event) {
+          wand.engine.renderNode(trigger.target);
+        };
+        break;
+
+      case 'externalFeedback':
+        var elem = document.createElement('div');
+        elem.innerHTML = triggerHtml;
+
+    }
 
     wand.elem.appendChild(button);
   }

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -49,17 +49,33 @@ var Wand = (function(wand, Handlebars) {
         break;
 
       case 'api':
+        var params = '';
         var elem = document.createElement('div');
+        elem.id = 'wand-trigger-' + trigger._id;
         elem.innerHTML = triggerHtml;
-        var _trigger = elem.querySelector('#Wand-js-' + trigger._id);
-        _trigger.onclick = function(event) {
-          var response = wand.util.loadXhr(trigger.api, function(xhr) {
-            if (xhr.status === 200) {
-              wand.engine.renderNode(trigger.callbackFn(xhr.response));
-            } else {
-              console.error('The XHR response returned an error!');
-            }
-          });
+        var submitButton = elem.querySelector('#Wand-submit-' + trigger._id);
+
+        submitButton.onclick = function(event) {
+          var inputData = elem.querySelector('#Wand-input-' + trigger._id);
+
+          if (trigger.preprocessor) {
+            params = wand.util.encodeParams(trigger.preprocessor(inputData.value));
+          }
+
+          if (trigger.jsonp === true) {
+            var response = wand.util.loadJsonp(trigger.api, params, function(data) {
+              wand.engine.renderNode(trigger.callbackFn(data));
+            });
+          } else {
+            var response = wand.util.loadXhr(trigger, params, function(xhr) {
+              if (xhr.status === 200) {
+                wand.engine.renderNode(trigger.callbackFn(xhr.response));
+              } else {
+                console.error('The XHR response returned an error!');
+              }
+            });
+          }
+
         };
 
         wand.elem.appendChild(elem);

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -26,12 +26,13 @@ var Wand = (function(wand, Handlebars) {
     wand.elem.innerHTML = Handlebars.compile(wand.template.node)(node);
     if (node.triggers) {
       for (var i = node.triggers.length - 1; i >= 0; i--) {
-        renderTrigger(node.triggers[i], node.type);
+        renderTrigger(node.triggers[i], i, node.type);
       }
     }
   };
 
-  function renderTrigger(trigger, type) {
+  function renderTrigger(trigger, id, type) {
+    trigger._id = id;
     var triggerHtml = Handlebars.compile(wand.template.triggers[type])(trigger);
 
     switch (type) {
@@ -42,15 +43,30 @@ var Wand = (function(wand, Handlebars) {
         button.onclick = function(event) {
           wand.engine.renderNode(trigger.target);
         };
+
+        wand.elem.appendChild(button);
+
         break;
 
-      case 'externalFeedback':
+      case 'api':
         var elem = document.createElement('div');
         elem.innerHTML = triggerHtml;
+        var _trigger = elem.querySelector('#Wand-js-' + trigger._id);
+        _trigger.onclick = function(event) {
+          var response = wand.util.loadXhr(trigger.api, function(xhr) {
+            if (xhr.status === 200) {
+              wand.engine.renderNode(trigger.callbackFn(xhr.response));
+            } else {
+              console.error('The XHR response returned an error!');
+            }
+          });
+        };
 
+        wand.elem.appendChild(elem);
+
+        break;
     }
 
-    wand.elem.appendChild(button);
   }
 
   return wand;

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -11,7 +11,10 @@ var Wand = (function(wand) {
 
   wand.template.triggers = {
 
-    'pickOne': '{{content}}'
+    'pickOne': '{{content}}',
+
+    'custom': '<input type="text" />' +
+      '<button id="Wand-js-{{target}}">{{content}}</button>'
 
   };
 

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -13,8 +13,8 @@ var Wand = (function(wand) {
 
     'pickOne': '{{content}}',
 
-    'api': '<input type="text" />' +
-      '<button id="Wand-js-{{_id}}">{{content}}</button>'
+    'api': '<input type="text" id="Wand-input-{{_id}}" />' +
+      '<button type="button" id="Wand-submit-{{_id}}">{{content}}</button>'
 
   };
 

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -13,8 +13,8 @@ var Wand = (function(wand) {
 
     'pickOne': '{{content}}',
 
-    'custom': '<input type="text" />' +
-      '<button id="Wand-js-{{target}}">{{content}}</button>'
+    'api': '<input type="text" />' +
+      '<button id="Wand-js-{{_id}}">{{content}}</button>'
 
   };
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1,0 +1,29 @@
+var Wand = (function(wand) {
+
+  'use strict';
+
+  wand = wand || {};
+  wand.util = {};
+
+  wand.util.loadXhr = function(url, callback) {
+    console.debug('Retrieving url ' + url);
+    return getRequest(url, callback);
+  };
+
+  function getRequest(url, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', encodeURI(url));
+
+    xhr.onload = callback.bind(this, xhr);
+    xhr.onerror = function(xhr) {
+      console.error(xhr);
+    };
+
+    xhr.send();
+
+    return xhr;
+  }
+
+  return wand;
+
+}(Wand || {}));

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -1,5 +1,6 @@
 var Wand = (function(wand) {
 
+  /*jshint validthis: true */
   'use strict';
 
   wand = wand || {};

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -6,12 +6,34 @@ var Wand = (function(wand) {
   wand = wand || {};
   wand.util = {};
 
-  wand.util.loadXhr = function(url, callback) {
-    console.debug('Retrieving url ' + url);
-    return getRequest(url, callback);
+  wand.util.encodeParams = function(objParams) {
+    var str = [];
+    for(var p in objParams)
+      if (objParams.hasOwnProperty(p)) {
+        str.push(encodeURIComponent(p) + "=" + encodeURIComponent(objParams[p]));
+      }
+    return str.join("&");
   };
 
-  function getRequest(url, callback) {
+  wand.util.loadXhr = function(trigger, params, callback) {
+    console.debug('Retrieving url ' + trigger.url);
+    return getRequest(trigger.url, params, callback);
+  };
+
+  wand.util.loadJsonp = function(url, params, callback) {
+    var callbackName = 'jsonp_callback_' + Math.round(100000 * Math.random());
+    window[callbackName] = function(data) {
+      delete window[callbackName];
+      document.body.removeChild(script);
+      callback(data);
+    };
+
+    var script = document.createElement('script');
+    script.src = url + (url.indexOf('?') >= 0 ? '&' : '?') + params + '&callback=' + callbackName;
+    document.body.appendChild(script);
+  };
+
+  function getRequest(url, params, callback) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', encodeURI(url));
 
@@ -20,7 +42,7 @@ var Wand = (function(wand) {
       console.error(xhr);
     };
 
-    xhr.send();
+    xhr.send(params);
 
     return xhr;
   }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -8,10 +8,11 @@ var Wand = (function(wand) {
 
   wand.util.encodeParams = function(objParams) {
     var str = [];
-    for(var p in objParams)
+    for(var p in objParams) {
       if (objParams.hasOwnProperty(p)) {
         str.push(encodeURIComponent(p) + "=" + encodeURIComponent(objParams[p]));
       }
+    }
     return str.join("&");
   };
 

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -7,6 +7,7 @@ var Wand = (function(wand) {
   var options, nodes;
 
   var badHtmlError = new Error('You did not pass a valid HTML Element');
+  var noSuchCallbackError = new Error('We could not find a callback function with that name!');
 
   wand.init = function(opts) {
     // @params options - object that contains nodes and html container id
@@ -21,6 +22,10 @@ var Wand = (function(wand) {
     wand.elem = document.getElementById(opts.elem);
     wand.elem.className += ' wand';
 
+    if (!checkApiCallbackFns()) {
+      throw noSuchCallbackError;
+    }
+
     var _firstNode = wand.state.init();
     wand.engine.renderNode(_firstNode);
 
@@ -29,6 +34,28 @@ var Wand = (function(wand) {
     };
 
   };
+
+  function checkApiCallbackFns() {
+    var validCallbackFns = true;
+    wand.opts.nodes.forEach(function(node) {
+      if (!node.type === 'api') {
+        return;
+      }
+      node.triggers.forEach(function(trigger) {
+        if (isFunction((wand.opts.callbackFns[trigger.callbackFn]))) {
+          trigger.callbackFn = wand.opts.callbackFns[trigger.callbackFn];
+          return;
+        }
+        validCallbackFns = false;
+      });
+    });
+    return validCallbackFns;
+  };
+
+  // stolen from underscore.js
+  function isFunction(obj) {
+    return !!(obj && obj.constructor && obj.call && obj.apply);
+  }
 
   return wand;
 

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -38,23 +38,50 @@ var Wand = (function(wand) {
   function checkApiCallbackFns() {
     var validCallbackFns = true;
     wand.opts.nodes.forEach(function(node) {
+
       if (node.type !== 'api') {
         return;
       }
+
       node.triggers.forEach(function(trigger) {
-        if (isFunction((wand.opts.callbackFns[trigger.callbackFn]))) {
-          trigger.callbackFn = wand.opts.callbackFns[trigger.callbackFn];
+        var triggerFn = getFuncFromString(trigger.callbackFn);
+        if (triggerFn !== null) {
+          trigger.callbackFn = triggerFn;
           return;
         }
         validCallbackFns = false;
       });
+
     });
+
     return validCallbackFns;
+
   }
 
-  // stolen from underscore.js
-  function isFunction(obj) {
-    return !!(obj && obj.constructor && obj.call && obj.apply);
+  /**
+   * Converts a string containing a function or object method name to a function pointer.
+   * @param  string   func
+   * @return function
+   */
+  function getFuncFromString(func) {
+    // if already a function, return
+    if (typeof func === 'function') { return func; }
+
+    // if string, try to find function or method of object (of "obj.func" format)
+    if (typeof func === 'string') {
+      if (!func.length) { return null; }
+      var target = window;
+      var _func = func.split('.');
+      while (_func.length) {
+        var ns = _func.shift();
+        if (typeof target[ns] === 'undefined') { return null; }
+        target = target[ns];
+      }
+      if (typeof target === 'function') { return target; }
+    }
+
+      // return null if could not parse
+      return null;
   }
 
   return wand;

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -22,7 +22,7 @@ var Wand = (function(wand) {
     wand.elem = document.getElementById(opts.elem);
     wand.elem.className += ' wand';
 
-    if (!checkApiCallbackFns()) {
+    if (checkApiCallbackFns() === false) {
       throw noSuchCallbackError;
     }
 
@@ -38,7 +38,7 @@ var Wand = (function(wand) {
   function checkApiCallbackFns() {
     var validCallbackFns = true;
     wand.opts.nodes.forEach(function(node) {
-      if (!node.type === 'api') {
+      if (node.type !== 'api') {
         return;
       }
       node.triggers.forEach(function(trigger) {
@@ -50,7 +50,7 @@ var Wand = (function(wand) {
       });
     });
     return validCallbackFns;
-  };
+  }
 
   // stolen from underscore.js
   function isFunction(obj) {

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -59,6 +59,15 @@ var Wand = (function(wand) {
     }
 
     node.triggers.forEach(function(trigger) {
+
+      // Let's call the (optional) preprocessor
+      if (trigger.preprocessor) {
+        var preprocessorFn = getFuncFromString(trigger.preprocessor);
+        if (preprocessorFn !== null) {
+          trigger.preprocessor = preprocessorFn;
+        }
+      }
+
       var triggerFn = getFuncFromString(trigger.callbackFn);
       if (triggerFn !== null) {
         trigger.callbackFn = triggerFn;

--- a/test/unit/wand.plugin.spec.js
+++ b/test/unit/wand.plugin.spec.js
@@ -3,7 +3,7 @@ describe('Wand plugin', function () {
   var _elem, wand;
   var expect = chai.expect;
   var elemId = 'testDiv';
-  var nodes = [{"id": 0}];
+  var nodes = [{"id": 0, 'triggers': []}];
   var opts = {elem: elemId, nodes: nodes};
 
   beforeEach(function () {

--- a/test/unit/wand.spec.js
+++ b/test/unit/wand.spec.js
@@ -3,8 +3,8 @@ describe('Wand', function () {
   var _elem, wand;
   var expect = chai.expect;
   var elemId = 'testDiv';
-  var nodes = [{"id": 0, 'title':"node 0 title"}];
-  var opts = {elem: elemId, nodes: nodes};
+  var nodes = [{"id": 0, 'title': "node 0 title", "triggers": []}];
+  var opts = {elem: elemId, nodes: nodes, callbackFns: []};
 
   beforeEach(function () {
     var _elem = document.createElement('div');

--- a/test/unit/wand.spec.js
+++ b/test/unit/wand.spec.js
@@ -1,16 +1,28 @@
+
 describe('Wand', function () {
 
-  var _elem, wand;
+  var _elem, wand, opts;
   var expect = chai.expect;
   var elemId = 'testDiv';
-  var nodes = [{"id": 0, 'title': "node 0 title", "triggers": []}];
-  var opts = {elem: elemId, nodes: nodes, callbackFns: []};
+  var nodes = [{"id": 0, 'type': 'pickOne', 'title': "node 0 title", "content": "foo", "triggers": []}];
+  var badApiTrigger = [{"callbackFn": "DOESNOTEXIST", "content": "test"}];
+  var goodApiTrigger = [{"callbackFn": "aFunction", "content": "test"}];
+  var nestedApiTrigger = [{"callbackFn": "nested.aFunction", "content": "test"}];
+
+  window.aFunction = function(){};
+  window.nested = {};
+  window.nested.aFunction = function(){};
 
   beforeEach(function () {
+    opts = {elem: elemId, nodes: nodes};
     var _elem = document.createElement('div');
     _elem.id = elemId;
     document.body.appendChild(_elem);
     wand = Wand;
+  });
+
+  afterEach(function() {
+    opts = {};
   });
 
   it('should fail without any options', function () {
@@ -28,6 +40,29 @@ describe('Wand', function () {
 
   it('should successfully initialize with a valid options', function () {
     wand.init(opts);
+  });
+
+  describe('Wand API Node', function() {
+
+    beforeEach(function() {
+      opts.nodes[0].type = 'api';
+    });
+
+    it('should fail to initialize if it cannot find a function in the callbackFns', function() {
+      opts.nodes[0].triggers = badApiTrigger;
+      expect(function() { wand.init(nodes); }).to.throw(Error);
+    });
+
+    it('should initialize properly if the callbackFns are registered', function() {
+      opts.nodes[0].triggers = goodApiTrigger;
+      wand.init(opts);
+    });
+
+    it('should initialize properly even with nested callbacks', function() {
+      opts.nodes[0].triggers = nestedApiTrigger;
+      wand.init(opts);
+    });
+
   });
 
 });

--- a/test/unit/wand.spec.js
+++ b/test/unit/wand.spec.js
@@ -34,8 +34,12 @@ describe('Wand', function () {
   });
 
   it('should fail with a bad html element', function () {
-    // test that we pass successfully
     expect(function(){ wand.init({elem: 'NOELEMENTHERE'}); } ).to.throw(Error);
+  });
+
+  it('should fail with duplicate nodes', function() {
+    opts.nodes = [{'id': 0}, {'id': 0}];
+    expect(function() { wand.init(opts); }).to.throw(Error);
   });
 
   it('should successfully initialize with a valid options', function () {

--- a/test/unit/wand.state.spec.js
+++ b/test/unit/wand.state.spec.js
@@ -7,10 +7,11 @@ describe('Wand State', function() {
     elem: elemId,
     nodes: [{
       "id": 0, "title": "First Node", "type": "pickOne",
-      "triggers": [{ "target": 1, "content": "test" }]
+      "triggers": [{ "target": 1, "content": "test" }],
     }, {
-      "id": 1, "title": "Second Node", "type": "pickOne"
-    }]
+      "id": 1, "title": "Second Node", "type": "pickOne", 'triggers': [],
+    }],
+    callbackFns: []
   };
 
   beforeEach(function() {
@@ -92,7 +93,5 @@ describe('Wand State', function() {
     var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
       results = regex.exec(location.search);
     return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
-  }
-
-
+  };
 });


### PR DESCRIPTION
**Don't merge this just yet!**

After some pair programming with @bsmithgall we started work on the idea of an API preprocessor. 

Why: for Miami's STEP wizard, @phiden uses a first API to convert an address to latitude longitude pairs. We take those pairs and feed it into a second API which will return whether or not the address is in unincorporated Miami-Dade County, and redirect down particular paths or expose nodes if necessary.

```
  {
    "id":0,
    "title": "The county check!",
    "content": "Enter your address in Miami:",
    "type": "api",
    "triggers": [
      {
        "content": "submit",
        "api": "http://still-eyrie-4551.herokuapp.com/areas",
        "preprocessor": "nested.preprocessor",
        "callbackFn": "nested.handleYesNoApi",
        "jsonp": true
      }
    ]
  }
```

http://localhost:4000/examples/api.html

Some additional work that needs to be done:
- [ ] Ernie to document some of the functions
- [x] Fix existing regression unit tests
- [ ] Preprocessor specific unit tests to be added

Some thoughts:
- Up until now we've inferred that a node of type `api` will have an input box. Does it make sense to move the `type` to the `triggers` array?
- Possible future feature consideration: the ability for an API result to show or hide nodes. 
