### PR TITLE
API trigger experiment branch

### DIFF
--- a/examples/api.html
+++ b/examples/api.html
@@ -8,44 +8,74 @@
 <body>
 <div id="wizard"></div>
 
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDzCsQTTBA7AbrjxE6R5vwnZkL0q7Ev48Q"></script>
 <script src="../dist/wand.js"></script>
 <script>
 
 var nested = {};
-nested.handleYesNoApi = function (xhrResponse) {
-  return JSON.parse(xhrResponse).answer === 'yes' ? 1 : 2;
+nested.preprocessor = function(address) {
+  // Preprocessors are optional.
+  /*
+  var geocoder = new google.maps.Geocoder();
+
+  geocoder.geocode(
+    {
+      "address": address,
+      "componentRestrictions": { "administrativeArea" : "Miami-Dade County" }
+    },
+    function(results, status) {
+      if (status == google.maps.GeocoderStatus.OK) {
+        lat = results[0].geometry.location.A;
+        lng = results[0].geometry.location.F;
+        return { lat: lat, lon: lng }
+      } else {
+          alert("Geocode was not successful for the following reason: " + status);
+      }
+    });
+
+  return address;
+  */
+  return { lat: 25.840171, lon: -8.179727 };
+};
+
+nested.handleYesNoApi = function(xhrResponse) {
+  // return JSON.parse(xhrResponse).answer === 'yes' ? 1 : 2;
+  return xhrResponse.features.length > 0 ? 'UMSA_false' : 'UMSA_true';
 };
 
 var options = {
-  elem: "wizard",
-  nodes: [
+  "elem": "wizard",
+  "nodes": [
   {
     "id":0,
-    "title": "Some Title",
-    "content": "Do you want a thing or another thing?",
+    "title": "The county check!",
+    "content": "Enter your address in Miami:",
     "type": "api",
     "triggers": [
       {
-        "content": "Is it yes or no?",
-        "api": "http://yesno.wtf/api",
-        "callbackFn": "nested.handleYesNoApi"
+        "content": "submit",
+        "api": "http://still-eyrie-4551.herokuapp.com/areas",
+        "preprocessor": "nested.preprocessor",
+        "callbackFn": "nested.handleYesNoApi",
+        "jsonp": true
       }
     ]
   },
   {
-    "id": 1,
+    "id": "UMSA_false",
     "title": "YES!",
-    "content": "You got yes!",
+    "content": "You are in a municipality in Miami-Dade.",
     "type": "pickOne",
     "triggers": []
   },
   {
-    "id": 2,
+    "id": "UMSA_true",
     "title": "NO!",
-    "content": "You got no!",
+    "content": "You are in Unincorporated Miami-Dade County!",
     "type": "pickOne",
     "triggers": []
-  }],
+  }]
 };
 
 Wand.init(options);

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -56,6 +56,7 @@ var Wand = (function(wand, Handlebars) {
         var submitButton = elem.querySelector('#Wand-submit-' + trigger._id);
 
         submitButton.onclick = function(event) {
+          var response;
           var inputData = elem.querySelector('#Wand-input-' + trigger._id);
 
           if (trigger.preprocessor) {
@@ -63,11 +64,11 @@ var Wand = (function(wand, Handlebars) {
           }
 
           if (trigger.jsonp === true) {
-            var response = wand.util.loadJsonp(trigger.api, params, function(data) {
+            response = wand.util.loadJsonp(trigger.api, params, function(data) {
               wand.engine.renderNode(trigger.callbackFn(data));
             });
           } else {
-            var response = wand.util.loadXhr(trigger, params, function(xhr) {
+            response = wand.util.loadXhr(trigger, params, function(xhr) {
               if (xhr.status === 200) {
                 wand.engine.renderNode(trigger.callbackFn(xhr.response));
               } else {

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -5,6 +5,11 @@ var Wand = (function(wand, Handlebars) {
   wand = wand || {};
   wand.engine = {};
 
+/**
+ * Renders the node given the id.
+ * @param {string} nodeId - The id of the trigger node.
+ * @returns {object} The node of the wizard
+ */
   function getNode(nodeId) {
     for (var i = wand.opts.nodes.length - 1; i >= 0; i--) {
       if (wand.opts.nodes[i].id === nodeId) {
@@ -15,6 +20,10 @@ var Wand = (function(wand, Handlebars) {
     return;
   }
 
+/**
+ * Renders the node and the triggers for that node.
+ * @param {string} nodeId - The id of the trigger node.
+ */
   wand.engine.renderNode = function(nodeId) {
     var node = getNode(nodeId);
     if (!node) {
@@ -31,6 +40,12 @@ var Wand = (function(wand, Handlebars) {
     }
   };
 
+/**
+ * Renders the triggers, event handlers and performs necessary business logic.
+ * @param {object} trigger - The trigger object.
+ * @param {string} id - The id of the trigger node.
+ * @param {string} type - Renders a specific trigger type (pickOne, api, etc.)
+ */
   function renderTrigger(trigger, id, type) {
     trigger._id = id;
     var triggerHtml = Handlebars.compile(wand.template.triggers[type])(trigger);

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -49,17 +49,33 @@ var Wand = (function(wand, Handlebars) {
         break;
 
       case 'api':
+        var params = '';
         var elem = document.createElement('div');
+        elem.id = 'wand-trigger-' + trigger._id;
         elem.innerHTML = triggerHtml;
-        var _trigger = elem.querySelector('#Wand-js-' + trigger._id);
-        _trigger.onclick = function(event) {
-          var response = wand.util.loadXhr(trigger.api, function(xhr) {
-            if (xhr.status === 200) {
-              wand.engine.renderNode(trigger.callbackFn(xhr.response));
-            } else {
-              console.error('The XHR response returned an error!');
-            }
-          });
+        var submitButton = elem.querySelector('#Wand-submit-' + trigger._id);
+
+        submitButton.onclick = function(event) {
+          var inputData = elem.querySelector('#Wand-input-' + trigger._id);
+
+          if (trigger.preprocessor) {
+            params = wand.util.encodeParams(trigger.preprocessor(inputData.value));
+          }
+
+          if (trigger.jsonp === true) {
+            var response = wand.util.loadJsonp(trigger.api, params, function(data) {
+              wand.engine.renderNode(trigger.callbackFn(data));
+            });
+          } else {
+            var response = wand.util.loadXhr(trigger, params, function(xhr) {
+              if (xhr.status === 200) {
+                wand.engine.renderNode(trigger.callbackFn(xhr.response));
+              } else {
+                console.error('The XHR response returned an error!');
+              }
+            });
+          }
+
         };
 
         wand.elem.appendChild(elem);

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -13,8 +13,8 @@ var Wand = (function(wand) {
 
     'pickOne': '{{content}}',
 
-    'api': '<input type="text" />' +
-      '<button id="Wand-js-{{_id}}">{{content}}</button>'
+    'api': '<input type="text" id="Wand-input-{{_id}}" />' +
+      '<button type="button" id="Wand-submit-{{_id}}">{{content}}</button>'
 
   };
 

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -6,6 +6,11 @@ var Wand = (function(wand) {
   wand = wand || {};
   wand.util = {};
 
+/**
+ * Take an object of parameters and convert it into a GET query string
+ * @param {object}
+ * @returns {string}
+ */
   wand.util.encodeParams = function(objParams) {
     var str = [];
     for(var p in objParams) {
@@ -16,11 +21,23 @@ var Wand = (function(wand) {
     return str.join("&");
   };
 
+/**
+ * Make an XHR call for regular APIs that don't have CORS issues.
+ * @param {string} url
+ * @param {string} params
+ * @param {function} callback
+ */
   wand.util.loadXhr = function(trigger, params, callback) {
     console.debug('Retrieving url ' + trigger.url);
     return getRequest(trigger.url, params, callback);
   };
 
+/**
+ * For APIs that have Cross-origin resource sharing issues, bring in a method for JSONP.
+ * @param {string} url
+ * @param {string} params
+ * @param {function} callback
+ */
   wand.util.loadJsonp = function(url, params, callback) {
     var callbackName = 'jsonp_callback_' + Math.round(100000 * Math.random());
     window[callbackName] = function(data) {
@@ -34,6 +51,12 @@ var Wand = (function(wand) {
     document.body.appendChild(script);
   };
 
+/**
+ * Handles XMLHttpRequests, similar to jQuery's .ajax method.
+ * @param {string} url
+ * @param {string} params
+ * @param {function} callback
+ */
   function getRequest(url, params, callback) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', encodeURI(url));

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -6,12 +6,34 @@ var Wand = (function(wand) {
   wand = wand || {};
   wand.util = {};
 
-  wand.util.loadXhr = function(url, callback) {
-    console.debug('Retrieving url ' + url);
-    return getRequest(url, callback);
+  wand.util.encodeParams = function(objParams) {
+    var str = [];
+    for(var p in objParams)
+      if (objParams.hasOwnProperty(p)) {
+        str.push(encodeURIComponent(p) + "=" + encodeURIComponent(objParams[p]));
+      }
+    return str.join("&");
   };
 
-  function getRequest(url, callback) {
+  wand.util.loadXhr = function(trigger, params, callback) {
+    console.debug('Retrieving url ' + trigger.url);
+    return getRequest(trigger.url, params, callback);
+  };
+
+  wand.util.loadJsonp = function(url, params, callback) {
+    var callbackName = 'jsonp_callback_' + Math.round(100000 * Math.random());
+    window[callbackName] = function(data) {
+      delete window[callbackName];
+      document.body.removeChild(script);
+      callback(data);
+    };
+
+    var script = document.createElement('script');
+    script.src = url + (url.indexOf('?') >= 0 ? '&' : '?') + params + '&callback=' + callbackName;
+    document.body.appendChild(script);
+  };
+
+  function getRequest(url, params, callback) {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', encodeURI(url));
 
@@ -20,7 +42,7 @@ var Wand = (function(wand) {
       console.error(xhr);
     };
 
-    xhr.send();
+    xhr.send(params);
 
     return xhr;
   }

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -8,10 +8,11 @@ var Wand = (function(wand) {
 
   wand.util.encodeParams = function(objParams) {
     var str = [];
-    for(var p in objParams)
+    for(var p in objParams) {
       if (objParams.hasOwnProperty(p)) {
         str.push(encodeURIComponent(p) + "=" + encodeURIComponent(objParams[p]));
       }
+    }
     return str.join("&");
   };
 

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -90,11 +90,11 @@ var Wand = (function(wand) {
 
   }
 
-  /**
-   * Converts a string containing a function or object method name to a function pointer.
-   * @param  string   func
-   * @return function
-   */
+/**
+ * Converts a string containing a function or object method name to a function pointer.
+ * @param {string} func
+ * @return {function}
+ */
   function getFuncFromString(func) {
     // if already a function, return
     if (typeof func === 'function') { return func; }

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -59,6 +59,15 @@ var Wand = (function(wand) {
     }
 
     node.triggers.forEach(function(trigger) {
+
+      // Let's call the (optional) preprocessor
+      if (trigger.preprocessor) {
+        var preprocessorFn = getFuncFromString(trigger.preprocessor);
+        if (preprocessorFn !== null) {
+          trigger.preprocessor = preprocessorFn;
+        }
+      }
+
       var triggerFn = getFuncFromString(trigger.callbackFn);
       if (triggerFn !== null) {
         trigger.callbackFn = triggerFn;


### PR DESCRIPTION
**Don't merge this just yet!**

After some pair programming with @bsmithgall we started work on the idea of an API preprocessor. 

Why: for Miami's STEP wizard, @phiden uses a first API to convert an address to latitude longitude pairs. We take those pairs and feed it into a second API which will return whether or not the address is in unincorporated Miami-Dade County, and redirect down particular paths or expose nodes if necessary.

```
  {
    "id":0,
    "title": "The county check!",
    "content": "Enter your address in Miami:",
    "type": "api",
    "triggers": [
      {
        "content": "submit",
        "api": "http://still-eyrie-4551.herokuapp.com/areas",
        "preprocessor": "nested.preprocessor",
        "callbackFn": "nested.handleYesNoApi",
        "jsonp": true
      }
    ]
  }
```

http://localhost:4000/examples/api.html

Some additional work that needs to be done:
- [x] Ernie to document some of the functions
- [x] Fix existing regression unit tests
- [ ] Preprocessor specific unit tests to be added

Some thoughts:
- Up until now we've inferred that a node of type `api` will have an input box. Does it make sense to move the `type` to the `triggers` array?
- Possible future feature consideration: the ability for an API result to show or hide nodes. 
