### PR TITLE
Replacing ajax-themed api with custom callback

### DIFF
--- a/examples/api.html
+++ b/examples/api.html
@@ -12,12 +12,12 @@
 <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDzCsQTTBA7AbrjxE6R5vwnZkL0q7Ev48Q"></script>
 <script src="../dist/wand.js"></script>
 <script>
+function ajaxCallback(data){
+  var nodeId = data.features.length > 0 ? 'UMSA_false' : 'UMSA_true';
+  Wand.engine.renderNode(nodeId);
+};
 
-var nested = {};
-nested.preprocessor = function(address) {
-  // Preprocessors are optional. The return value of the preprocessor function
-  // would be fed as parameters into the functional callback (callbackFn).
-  /*
+function amIInMiami(address) {
   var geocoder = new google.maps.Geocoder();
 
   geocoder.geocode(
@@ -27,23 +27,20 @@ nested.preprocessor = function(address) {
     },
     function(results, status) {
       if (status == google.maps.GeocoderStatus.OK) {
-        lat = results[0].geometry.location.A;
-        lng = results[0].geometry.location.F;
-        return { lat: lat, lon: lng }
+        var lat = results[0].geometry.location.lat();
+        var lng = results[0].geometry.location.lng();
+        $.ajax({
+          url: "http://still-eyrie-4551.herokuapp.com/areas",
+          data: { lat: lat, lon: lng },
+          dataType: "jsonp",
+          method: "POST",
+        }).done(ajaxCallback);
       } else {
           alert("Geocode was not successful for the following reason: " + status);
       }
     });
+}
 
-  return address;
-  */
-  return { lat: 25.840171, lon: -8.179727 };
-};
-
-nested.handleYesNoApi = function(preprocessorResponse) {
-  // return JSON.parse(preprocessorResponse).answer === 'yes' ? 1 : 2;
-  return preprocessorResponse.features.length > 0 ? 'UMSA_false' : 'UMSA_true';
-};
 
 var options = {
   "elem": "wizard",
@@ -52,14 +49,11 @@ var options = {
     "id":0,
     "title": "The county check!",
     "content": "Enter your address in Miami:",
-    "type": "api",
+    "type": "custom",
     "triggers": [
       {
         "content": "submit",
-        "api": "http://still-eyrie-4551.herokuapp.com/areas",
-        "preprocessor": "nested.preprocessor",
-        "callbackFn": "nested.handleYesNoApi",
-        "jsonp": true
+        "callbackFn": "amIInMiami",
       }
     ]
   },

--- a/src/js/engine.js
+++ b/src/js/engine.js
@@ -45,7 +45,7 @@ var Wand = (function(wand, Handlebars) {
  * Renders the triggers, event handlers and performs necessary business logic.
  * @param {object} trigger - The trigger object.
  * @param {string} id - The id of the trigger node.
- * @param {string} type - Renders a specific trigger type (pickOne, api, etc.)
+ * @param {string} type - Renders a specific trigger type (pickOne, custom, etc.)
  */
   function renderTrigger(trigger, id, type) {
     trigger._id = id;
@@ -63,7 +63,7 @@ var Wand = (function(wand, Handlebars) {
 
         break;
 
-      case 'api':
+      case 'custom':
         var params = '';
         var elem = document.createElement('div');
         elem.id = 'wand-trigger-' + trigger._id;
@@ -71,27 +71,8 @@ var Wand = (function(wand, Handlebars) {
         var submitButton = elem.querySelector('#Wand-submit-' + trigger._id);
 
         submitButton.onclick = function(event) {
-          var response;
-          var inputData = elem.querySelector('#Wand-input-' + trigger._id);
-
-          if (trigger.preprocessor) {
-            params = wand.util.encodeParams(trigger.preprocessor(inputData.value));
-          }
-
-          if (trigger.jsonp === true) {
-            response = wand.util.loadJsonp(trigger.api, params, function(data) {
-              wand.engine.renderNode(trigger.callbackFn(data));
-            });
-          } else {
-            response = wand.util.loadXhr(trigger, params, function(xhr) {
-              if (xhr.status === 200) {
-                wand.engine.renderNode(trigger.callbackFn(xhr.response));
-              } else {
-                console.error('The XHR response returned an error!');
-              }
-            });
-          }
-
+          var inputElem = elem.querySelector('#Wand-input-' + trigger._id);
+          trigger.callbackFn(inputElem.value);
         };
 
         wand.nodeContainer.appendChild(elem);

--- a/src/js/templates.js
+++ b/src/js/templates.js
@@ -13,7 +13,7 @@ var Wand = (function(wand) {
 
     'pickOne': '{{content}}',
 
-    'api': '<input type="text" id="Wand-input-{{_id}}" />' +
+    'custom': '<input type="text" id="Wand-input-{{_id}}" />' +
       '<button type="button" id="Wand-submit-{{_id}}">{{content}}</button>'
 
   };

--- a/src/js/util.js
+++ b/src/js/util.js
@@ -33,25 +33,6 @@ var Wand = (function(wand) {
   };
 
 /**
- * For APIs that have Cross-origin resource sharing issues, bring in a method for JSONP.
- * @param {string} url
- * @param {string} params
- * @param {function} callback
- */
-  wand.util.loadJsonp = function(url, params, callback) {
-    var callbackName = 'jsonp_callback_' + Math.round(100000 * Math.random());
-    window[callbackName] = function(data) {
-      delete window[callbackName];
-      document.body.removeChild(script);
-      callback(data);
-    };
-
-    var script = document.createElement('script');
-    script.src = url + (url.indexOf('?') >= 0 ? '&' : '?') + params + '&callback=' + callbackName;
-    document.body.appendChild(script);
-  };
-
-/**
  * Handles XMLHttpRequests, similar to jQuery's .ajax method.
  * @param {string} url
  * @param {string} params

--- a/src/js/wand.js
+++ b/src/js/wand.js
@@ -64,7 +64,7 @@ var Wand = (function(wand) {
 
   function hasValidApiCallbackFns(node) {
     var validCallbackFns = true;
-    if (node.type !== 'api') {
+    if (node.type !== 'custom') {
       return;
     }
 

--- a/test/unit/wand.spec.js
+++ b/test/unit/wand.spec.js
@@ -10,11 +10,9 @@ describe('Wand', function () {
   var nestedApiTrigger = [{"callbackFn": "nested.aFunction", "content": "test"}];
 
   var goodPreTrigger = [{ "callbackFn": "aFunction",
-                          "preprocessor": "bFunction",
                           "content": "test"}];
 
   var badPreTrigger = [{ "callbackFn": "aFunction",
-                          "preprocessor": "DOESNOTEXIST",
                           "content": "test"}];
 
   window.aFunction = function(){};
@@ -67,7 +65,7 @@ describe('Wand', function () {
   describe('Wand API Node', function() {
 
     beforeEach(function() {
-      opts.nodes[0].type = 'api';
+      opts.nodes[0].type = 'custom';
     });
 
     it('should fail to initialize if it cannot find a function in the callbackFns', function() {

--- a/test/unit/wand.spec.js
+++ b/test/unit/wand.spec.js
@@ -85,16 +85,6 @@ describe('Wand', function () {
       wand.init(opts);
     });
 
-    it('should initialize with a preprocessor', function() {
-      opts.nodes[0].triggers = goodPreTrigger;
-      wand.init(opts);
-    });
-
-    it('should fail to initialize with a bad preprocessor', function() {
-      opts.nodes[0].triggers = badPreTrigger;
-      wand.init(opts);
-    });
-
   });
 
 });


### PR DESCRIPTION
- 'api' type --> 'custom' type
- wand doesn't do ajax for the api user
- api user calls `Wand.engine.renderNode` with next `nodeId`
- removed pre & post processing
- removed obselete tests for pre & post processing
